### PR TITLE
mark some modules as required only for tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,13 +4,15 @@ requires 'Crypt::OpenSSL::DSA';
 requires 'Crypt::OpenSSL::RSA';
 requires 'Date::Format';
 requires 'Digest::SHA';
-requires 'File::Which';
 requires 'Google::SAML::Request';
 requires 'HTML::Entities';
-requires 'Test::Exception';
-requires 'Test::Most';
 requires 'XML::CanonicalizeXML';
 
 on build => sub {
     requires 'ExtUtils::MakeMaker', '6.36';
+};
+on test => sub {
+    requires 'File::Which';
+    requires 'Test::Most';
+    requires 'Test::Exception';
 };


### PR DESCRIPTION
I wanted also to mark DSA module  as 'suggests' instead of requires, but then I noticed that it is required in tests.
